### PR TITLE
Fix broken navigation links in all HTML pages.

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -78,15 +78,15 @@
     <header id="main-header" class="fixed top-0 left-0 right-0 z-40 transition-all duration-300 ease-in-out">
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
             <!-- Logo -->
-            <a href="/" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
+            <a href="index.html" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
                 terraaZac
             </a>
 
             <!-- Navegación Desktop -->
             <div class="hidden md:flex items-center space-x-8">
-                <a href="/index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
-                <a href="/servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
+                <a href="contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="bg-brand-accent-1 text-white px-5 py-2 rounded-full font-semibold hover:bg-opacity-90 transition-all">
                     Reservar por WhatsApp
                 </a>
@@ -108,9 +108,9 @@
                 </button>
             </div>
             <div class="flex flex-col items-center justify-center space-y-8 mt-16">
-                <a href="/index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
-                <a href="/servicios.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="servicios.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
+                <a href="contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="mt-8 bg-brand-accent-1 text-white px-8 py-3 rounded-full font-semibold hover:bg-opacity-90 transition-all text-lg">
                     Reservar por WhatsApp
                 </a>

--- a/index.html
+++ b/index.html
@@ -78,15 +78,15 @@
     <header id="main-header" class="fixed top-0 left-0 right-0 z-40 transition-all duration-300 ease-in-out">
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
             <!-- Logo -->
-            <a href="/" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
+            <a href="index.html" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
                 terraaZac
             </a>
 
             <!-- Navegación Desktop -->
             <div class="hidden md:flex items-center space-x-8">
-                <a href="/index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
-                <a href="/servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
+                <a href="contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="bg-brand-accent-1 text-white px-5 py-2 rounded-full font-semibold hover:bg-opacity-90 transition-all">
                     Reservar por WhatsApp
                 </a>
@@ -108,9 +108,9 @@
                 </button>
             </div>
             <div class="flex flex-col items-center justify-center space-y-8 mt-16">
-                <a href="/index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
                 <a href="servicios.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="mt-8 bg-brand-accent-1 text-white px-8 py-3 rounded-full font-semibold hover:bg-opacity-90 transition-all text-lg">
                     Reservar por WhatsApp
                 </a>

--- a/letras.html
+++ b/letras.html
@@ -78,15 +78,15 @@
     <header id="main-header" class="fixed top-0 left-0 right-0 z-40 transition-all duration-300 ease-in-out">
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
             <!-- Logo -->
-            <a href="/" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
+            <a href="index.html" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
                 terraaZac
             </a>
 
             <!-- Navegación Desktop -->
             <div class="hidden md:flex items-center space-x-8">
-                <a href="/index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
-                <a href="/servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
+                <a href="contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="bg-brand-accent-1 text-white px-5 py-2 rounded-full font-semibold hover:bg-opacity-90 transition-all">
                     Reservar por WhatsApp
                 </a>
@@ -108,9 +108,9 @@
                 </button>
             </div>
             <div class="flex flex-col items-center justify-center space-y-8 mt-16">
-                <a href="/index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
-                <a href="/servicios.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="servicios.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
+                <a href="contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="mt-8 bg-brand-accent-1 text-white px-8 py-3 rounded-full font-semibold hover:bg-opacity-90 transition-all text-lg">
                     Reservar por WhatsApp
                 </a>

--- a/revelacion.html
+++ b/revelacion.html
@@ -78,15 +78,15 @@
     <header id="main-header" class="fixed top-0 left-0 right-0 z-40 transition-all duration-300 ease-in-out">
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
             <!-- Logo -->
-            <a href="/" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
+            <a href="index.html" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
                 terraaZac
             </a>
 
             <!-- Navegación Desktop -->
             <div class="hidden md:flex items-center space-x-8">
-                <a href="/index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
-                <a href="/servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
+                <a href="contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="bg-brand-accent-1 text-white px-5 py-2 rounded-full font-semibold hover:bg-opacity-90 transition-all">
                     Reservar por WhatsApp
                 </a>
@@ -108,9 +108,9 @@
                 </button>
             </div>
             <div class="flex flex-col items-center justify-center space-y-8 mt-16">
-                <a href="/index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
-                <a href="/servicios.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="servicios.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
+                <a href="contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="mt-8 bg-brand-accent-1 text-white px-8 py-3 rounded-full font-semibold hover:bg-opacity-90 transition-all text-lg">
                     Reservar por WhatsApp
                 </a>

--- a/servicios.html
+++ b/servicios.html
@@ -78,15 +78,15 @@
     <header id="main-header" class="fixed top-0 left-0 right-0 z-40 transition-all duration-300 ease-in-out">
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
             <!-- Logo -->
-            <a href="/" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
+            <a href="index.html" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
                 terraaZac
             </a>
 
             <!-- Navegación Desktop -->
             <div class="hidden md:flex items-center space-x-8">
-                <a href="/index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
-                <a href="/servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
+                <a href="contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="bg-brand-accent-1 text-white px-5 py-2 rounded-full font-semibold hover:bg-opacity-90 transition-all">
                     Reservar por WhatsApp
                 </a>
@@ -108,9 +108,9 @@
                 </button>
             </div>
             <div class="flex flex-col items-center justify-center space-y-8 mt-16">
-                <a href="/index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
-                <a href="/servicios.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="servicios.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
+                <a href="contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="mt-8 bg-brand-accent-1 text-white px-8 py-3 rounded-full font-semibold hover:bg-opacity-90 transition-all text-lg">
                     Reservar por WhatsApp
                 </a>

--- a/terraza.html
+++ b/terraza.html
@@ -78,15 +78,15 @@
     <header id="main-header" class="fixed top-0 left-0 right-0 z-40 transition-all duration-300 ease-in-out">
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
             <!-- Logo -->
-            <a href="/" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
+            <a href="index.html" class="text-2xl font-bold text-brand-text-primary hover:text-brand-accent-2 transition-colors">
                 terraaZac
             </a>
 
             <!-- Navegación Desktop -->
             <div class="hidden md:flex items-center space-x-8">
-                <a href="/index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
-                <a href="/servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="index.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="servicios.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
+                <a href="contacto.html" class="text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="bg-brand-accent-1 text-white px-5 py-2 rounded-full font-semibold hover:bg-opacity-90 transition-all">
                     Reservar por WhatsApp
                 </a>
@@ -108,9 +108,9 @@
                 </button>
             </div>
             <div class="flex flex-col items-center justify-center space-y-8 mt-16">
-                <a href="/index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
-                <a href="/servicios.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
-                <a href="/contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
+                <a href="index.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Inicio</a>
+                <a href="servicios.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Servicios</a>
+                <a href="contacto.html" class="text-2xl text-brand-text-primary hover:text-brand-accent-2 transition-colors">Contacto</a>
                 <a href="https://wa.me/5214922461907?text=Hola%20quiero%20reservar%20en%20terraaZac" target="_blank" rel="noopener noreferrer" class="mt-8 bg-brand-accent-1 text-white px-8 py-3 rounded-full font-semibold hover:bg-opacity-90 transition-all text-lg">
                     Reservar por WhatsApp
                 </a>


### PR DESCRIPTION
The navigation links in the header were using absolute paths (e.g., `/servicios.html`), which caused 404 errors when the site was viewed locally as files.

This change updates all navigation links to use relative paths (e.g., `servicios.html`), ensuring they work correctly in all environments.